### PR TITLE
ping exporter fails to launch on new installs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 flask==2.2.2
+werkzeug>=2.2,<3.0
 grequests==0.4.0
 pyyaml==5.4
 gunicorn==19.9.0


### PR DESCRIPTION
Flask doesn't specify the dependency correctly (requirements says Werkzeug>=2.2.0). This is why, Werkzeug 3.0.0 is still installed and Flask 2.2.2 isn't made for Werkzeug 3.0.0.
Updated requirements.txt to fix this.